### PR TITLE
Skip deleted records

### DIFF
--- a/src/Job/Harvest.php
+++ b/src/Job/Harvest.php
@@ -191,6 +191,10 @@ class Harvest extends AbstractJob
             $toInsert = [];
             /** @var \SimpleXMLElement $record */
             foreach ($records->record as $record) {
+                if ($harvesterMap->isDeletedRecord($record)) {
+                    continue;
+                }
+
                 ++$stats['harvested'];
                 if ($whitelist || $blacklist) {
                     // Use xml instead of string because some formats may use


### PR DESCRIPTION
OAI-PMH repositories can return deleted records. These records do not have a `metadata` element and can cause an error that stop the harvesting process.
This patch makes the harvesting process ignore the deleted records.