### PR TITLE
Fix EntityManager error caused by clearing it

### DIFF
--- a/src/Job/Harvest.php
+++ b/src/Job/Harvest.php
@@ -301,7 +301,6 @@ class Harvest extends AbstractJob
                     $total += count($currentResults);
                     $identifierIds = array_merge($identifierIds, array_map($getId, array_values($currentResults)));
                     $this->createRollback($currentResults, $identifier);
-                    $this->entityManager->clear();
                 }
                 $identifierTotal = count($identifierIds);
                 if ($identifierTotal === count($resources)) {


### PR DESCRIPTION
The error message looks like this:

  Doctrine\ORM\ORMInvalidArgumentException: A new entity was found
  through the relationship 'Omeka\Entity\Resource#owner' that was not
  configured to cascade persist operations for entity:
  DoctrineProxies\__CG__\Omeka\Entity\User@409. To solve this issue:
  Either explicitly call EntityManager#persist() on this unknown entity
  or configure cascade persist this association in the mapping for
  example @ManyToOne(..,cascade={"persist"}). If you cannot find out
  which entity causes the problem implement
  'Omeka\Entity\User#__toString()' to get a clue.

It is not needed to clear it after each call to batchCreate as batchCreate automatically detaches new entities.

I watched memory usage of perform-job.php script during a harvest of 2300 items and it remained stable