### PR TITLE
Do not stop harvest when ListRecords request failed on the first try

### DIFF
--- a/src/Job/Harvest.php
+++ b/src/Job/Harvest.php
@@ -164,10 +164,10 @@ class Harvest extends AbstractJob
                                 'Error: the harvester does not list records with url %1$s.', // @translate
                                 $url
                             ));
+                            break;
                         }
                     }
                 }
-                break;
             }
 
             if (!$response->ListRecords) {


### PR DESCRIPTION
There are more retries after that, but no matter the result the code would always reach the `break` and leave the harvest loop.

This patch moves the `break` right after the failure of the last retry.