### PR TITLE
Fix isXmlEndpoint request URL

### DIFF
--- a/src/Mvc/Controller/Plugin/OaiPmhRepository.php
+++ b/src/Mvc/Controller/Plugin/OaiPmhRepository.php
@@ -90,7 +90,7 @@ class OaiPmhRepository extends AbstractPlugin
         }
 
         $url = $endpoint . '?verb=Identify';
-        $response = @\simplexml_load_file($url . '?verb=Identify');
+        $response = @\simplexml_load_file($url);
         return (bool) $response;
     }
 


### PR DESCRIPTION
`?verb=Identify` was appended twice to endpoint, resulting in URLs like this:

https://example.com/oai?verb=Identify?verb=Identify

This could result in servers returning a 500 error, thus failing the check even for valid OAI endpoints